### PR TITLE
use older ubuntu for building for linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             artifact_name: rat
             asset_name: rat_linux_x86_64


### PR DESCRIPTION
## what

downgrade from ubuntu 24.04 (which is what ubuntu-latest uses) to 20.04

## why

this is not a joke pr, this will seriously make linux builds more compatible with older systems (as ubuntu 24.04 uses glibc 2.39, your builds will dynamically link against glibc 2.39, and any systems with older glibc will fail to run the glorious rat)

## alternatives

there are a couple of alternatives to this approach, such as:

- ignore this pr and starve the poor outdated linux users of their much needed rat
- statically build with musl instead of glibc (although this is a pain in the ass if you dare use anything other than stdlib, which this project clearly does. result is very rewarding though)
- smash it with a hammer